### PR TITLE
Refactor into functions for testability

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+
+comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+omit =
+    */tests/*
+    */_version.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,3 +130,19 @@ jobs:
         if: matrix.os == 'windows'
         run: dependente --source=install,build
         shell: pwsh
+
+      - name: Run the tests
+        run: make test
+
+      - name: Convert coverage report to XML for codecov
+        run: coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          env_vars: OS,PYTHON,DEPENDENCIES
+          # Don't mark the job as failed if the upload fails for some reason.
+          # It does sometimes but shouldn't be the reason for running
+          # everything again unless something else is broken.
+          fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build, package, test, and clean
 PROJECT=dependente
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
+PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -vv --pyargs
 CHECK_STYLE=$(PROJECT)
 
 help:

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -12,8 +12,7 @@ import click
 import rich.console
 
 from .parsers import (
-    parse_pyproject_toml,
-    parse_setup_cfg,
+    parse_requirements,
     parse_sources,
     read_pyproject_toml,
     read_setup_cfg,
@@ -59,7 +58,6 @@ def main(source, verbose):
         style=style,
     )
     sources = parse_sources(source)
-    parsers = {"setup.cfg": parse_setup_cfg, "pyproject.toml": parse_pyproject_toml}
     readers = {"setup.cfg": read_setup_cfg, "pyproject.toml": read_pyproject_toml}
     dependencies = []
     for config_file in sources:
@@ -68,7 +66,7 @@ def main(source, verbose):
         try:
             console.print(f":mag_right: Parsing {config_file}: ", end="", style=style)
             config = readers[config_file]()
-            dependencies_found = parsers[config_file](config, sources[config_file])
+            dependencies_found = parse_requirements(config, sources[config_file])
             console.print(
                 f"{count(dependencies_found)} dependencies found", style=style
             )

--- a/dependente/parsers.py
+++ b/dependente/parsers.py
@@ -4,3 +4,122 @@
 """
 Functions for extracting the dependency information from files.
 """
+import configparser
+
+import tomli
+
+
+def parse_sources(source):
+    """
+    Parse the input string for sources and separate based on config file type.
+
+    Parameters
+    ----------
+    source : str
+        Input source specification.
+
+    Returns
+    -------
+    sources : dict
+        Dictionary of parse sources. Keys are config file names.
+    """
+    sources = {"setup.cfg": [], "pyproject.toml": []}
+    valid_sources = {
+        "install": {"file": "setup.cfg", "option": "install_requires"},
+        "extras": {"file": "setup.cfg", "option": "options.extras_require"},
+        "build": {"file": "pyproject.toml", "option": "build-system"},
+    }
+    for entry in sorted(source.strip().split(",")):
+        if entry not in valid_sources:
+            raise ValueError(
+                f"Invalid source '{entry}'. Must be one of {valid_sources}."
+            )
+        sources[valid_sources[entry]["file"]].append(valid_sources[entry]["option"])
+    return sources
+
+
+def read_setup_cfg(fname="setup.cfg"):
+    """
+    Read the setup.cfg file into a dictionary.
+    """
+    config = configparser.ConfigParser()
+    config.read(fname)
+    return config
+
+
+def parse_setup_cfg(config, sources):
+    """
+    Parse the sources from setup.cfg.
+
+    Parameters
+    ----------
+    config : dict
+        The configuration file read using configparser.
+    sources : list
+        List of section names from the config file.
+
+    Returns
+    -------
+    dependencies : list
+        List of dependencies read from the config file. Includes some comments.
+
+    """
+    requirements = []
+    for source in sources:
+        if source == "install_requires":
+            if source not in config["options"]:
+                raise ValueError(f"Missing '{source}' field in setup.cfg.")
+            requirements.append("# Install (run-time) dependencies from setup.cfg")
+            for package in config["options"][source].strip().split("\n"):
+                requirements.append(package.strip())
+        elif source == "options.extras_require":
+            if source not in config:
+                raise ValueError(f"Missing '{source}' section in setup.cfg.")
+            requirements.append("# Extra (optional) dependencies from setup.cfg")
+            for section in config[source]:
+                requirements.append(f"#   extra: {section}")
+                for package in config[source][section].strip().split("\n"):
+                    requirements.append(package.strip())
+    return requirements
+
+
+def read_pyproject_toml(fname="pyproject.toml"):
+    """
+    Read the pyproject.toml file into a dictionary.
+    """
+    with open(fname, "rb") as config_source:
+        config = tomli.load(config_source)
+    return config
+
+
+def parse_pyproject_toml(config, sources):
+    """
+    Parse the sources from pyproject.toml.
+
+    Parameters
+    ----------
+    config : dict
+        The configuration file read using tomli.
+    sources : list
+        List of section names from the config file.
+
+    Returns
+    -------
+    dependencies : list
+        List of dependencies read from the config file. Includes some comments.
+
+    """
+    requirements = []
+    for source in sources:
+        if source == "build-system":
+            if source not in config:
+                raise ValueError(f"Missing '{source}' section in pyproject.toml.")
+            requirements.append("# Build dependencies from pyproject.toml")
+            if "requires" not in config[source]:
+                raise ValueError(
+                    f"Missing 'requires' entry from the '{source}' section in "
+                    "pyproject.toml."
+                )
+            for package in config[source]["requires"]:
+                requirements.append(package.strip())
+    return requirements

--- a/dependente/parsers.py
+++ b/dependente/parsers.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Functions for extracting the dependency information from files.
+"""

--- a/dependente/parsers.py
+++ b/dependente/parsers.py
@@ -44,7 +44,6 @@ def read_setup_cfg(fname="setup.cfg"):
     """
     config = configparser.ConfigParser()
     config.read(fname)
-    print(fname, config)
     config_dict = {
         section: dict((key, value.strip()) for key, value in config.items(section))
         for section in config.sections()
@@ -78,12 +77,12 @@ def parse_requirements(config, sources):
         List of dependencies read from the config file. Includes some comments.
 
     """
-    requirements = []
     readers = {
         "install_requires": get_setup_cfg_install,
         "options.extras_require": get_setup_cfg_extras,
         "build-system": get_pyproject_toml_build,
     }
+    requirements = []
     for source in sources:
         requirements.extend(readers[source](config))
     return requirements

--- a/dependente/tests/conftest.py
+++ b/dependente/tests/conftest.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Fixtures for pytest
+"""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def setup_cfg():
+    "The text contents of the test file."
+    return str(Path(__file__).parent / "data" / "sample_setup.cfg")
+
+
+@pytest.fixture()
+def setup_cfg_config():
+    "The parsed contents of the file."
+    contents = {
+        "options": {
+            "python_requires": ">=3.6",
+            "install_requires": "click>=8.0.0,<9.0.0\nrich>=9.6.0,<11.0.0\ntomli>=1.0.0,<3.0.0",
+        },
+        "options.extras_require": {
+            "jupyter": "nbformat>=5.1",
+        },
+    }
+    return contents
+
+
+@pytest.fixture()
+def setup_cfg_install():
+    "The install requirements"
+    contents = [
+        "click>=8.0.0,<9.0.0",
+        "rich>=9.6.0,<11.0.0",
+        "tomli>=1.0.0,<3.0.0",
+    ]
+    return contents
+
+
+@pytest.fixture()
+def setup_cfg_extras():
+    "The extra requirements"
+    contents = [
+        "nbformat>=5.1",
+    ]
+    return contents
+
+
+@pytest.fixture()
+def pyproject_toml():
+    "The text contents of the test file."
+    return str(Path(__file__).parent / "data" / "sample_pyproject.toml")
+
+
+@pytest.fixture()
+def pyproject_toml_config():
+    "The parsed contents of the file."
+    contents = {
+        "build-system": {
+            "requires": [
+                "setuptools>=45",
+                "setuptools_scm>=6.2",
+                "wheel",
+            ]
+        },
+    }
+    return contents
+
+
+@pytest.fixture()
+def pyproject_toml_build():
+    "The build requirements"
+    contents = [
+        "setuptools>=45",
+        "setuptools_scm>=6.2",
+        "wheel",
+    ]
+    return contents

--- a/dependente/tests/data/sample_pyproject.toml
+++ b/dependente/tests/data/sample_pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm>=6.2", "wheel"]

--- a/dependente/tests/data/sample_setup.cfg
+++ b/dependente/tests/data/sample_setup.cfg
@@ -1,0 +1,10 @@
+[options]
+python_requires = >=3.6
+install_requires =
+    click>=8.0.0,<9.0.0
+    rich>=9.6.0,<11.0.0
+    tomli>=1.0.0,<3.0.0
+
+[options.extras_require]
+jupyter =
+    nbformat>=5.1

--- a/dependente/tests/test_parsers.py
+++ b/dependente/tests/test_parsers.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Test the functions that extract content from configuration files.
+"""
+from pathlib import Path
+
+import pytest
+
+from ..parsers import parse_sources
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("install", {"setup.cfg": ["install_requires"], "pyproject.toml": []}),
+        ("build", {"setup.cfg": [], "pyproject.toml": ["build-system"]}),
+        ("extras", {"setup.cfg": ["options.extras_require"], "pyproject.toml": []}),
+        (
+            "install,extras",
+            {
+                "setup.cfg": ["options.extras_require", "install_requires"],
+                "pyproject.toml": [],
+            },
+        ),
+        (
+            "extras,build",
+            {
+                "setup.cfg": ["options.extras_require"],
+                "pyproject.toml": ["build-system"],
+            },
+        ),
+        (
+            "build,extras,install",
+            {
+                "setup.cfg": ["options.extras_require", "install_requires"],
+                "pyproject.toml": ["build-system"],
+            },
+        ),
+    ],
+    ids=["install", "build", "extras", "install,extras", "extras,build", "all"],
+)
+def test_parse_sources(source, expected):
+    "Check the parsing of input data sources"
+    assert expected == parse_sources(source)
+
+
+def test_parse_sources_invalid():
+    "Should raise an exception on invalid input"
+    with pytest.raises(ValueError) as error:
+        parse_sources("something")
+    assert "'something'" in str(error)

--- a/dependente/tests/test_parsers.py
+++ b/dependente/tests/test_parsers.py
@@ -3,12 +3,20 @@
 # SPDX-License-Identifier: MIT
 """
 Test the functions that extract content from configuration files.
-"""
-from pathlib import Path
 
+The fixtures (arguments to the test functions) are defined in conftest.py
+"""
 import pytest
 
-from ..parsers import parse_sources
+from ..parsers import (
+    get_pyproject_toml_build,
+    get_setup_cfg_extras,
+    get_setup_cfg_install,
+    parse_requirements,
+    parse_sources,
+    read_pyproject_toml,
+    read_setup_cfg,
+)
 
 
 @pytest.mark.parametrize(
@@ -51,3 +59,82 @@ def test_parse_sources_invalid():
     with pytest.raises(ValueError) as error:
         parse_sources("something")
     assert "'something'" in str(error)
+
+
+def test_read_setup_cfg(setup_cfg, setup_cfg_config):
+    "Check that setup.cfg is read properly"
+    assert setup_cfg_config == read_setup_cfg(setup_cfg)
+
+
+def test_read_pyproject_toml(pyproject_toml, pyproject_toml_config):
+    "Check that pyproject.toml is read properly"
+    assert pyproject_toml_config == read_pyproject_toml(pyproject_toml)
+
+
+def test_parse_requirements_install(setup_cfg_config, setup_cfg_install):
+    "Check that setup.cfg parses install requirements properly"
+    parsed = [
+        line
+        for line in parse_requirements(setup_cfg_config, ["install_requires"])
+        if not line.startswith("#")
+    ]
+    assert setup_cfg_install == parsed
+
+
+def test_parse_requirements_extras(setup_cfg_config, setup_cfg_extras):
+    "Check that setup.cfg parses extra requirements properly"
+    parsed = [
+        line
+        for line in parse_requirements(setup_cfg_config, ["options.extras_require"])
+        if not line.startswith("#")
+    ]
+    assert setup_cfg_extras == parsed
+
+
+def test_parse_requirements_build(pyproject_toml_config, pyproject_toml_build):
+    "Check that pyproject.toml parses all requirements properly"
+    parsed = [
+        line
+        for line in parse_requirements(pyproject_toml_config, ["build-system"])
+        if not line.startswith("#")
+    ]
+    assert pyproject_toml_build == parsed
+
+
+def test_parse_requirements_multiple(
+    setup_cfg_config, setup_cfg_extras, setup_cfg_install
+):
+    "Check that setup.cfg parses all requirements properly"
+    parsed = [
+        line
+        for line in parse_requirements(
+            setup_cfg_config, ["options.extras_require", "install_requires"]
+        )
+        if not line.startswith("#")
+    ]
+    expected = setup_cfg_extras + setup_cfg_install
+    assert expected == parsed
+
+
+def test_parse_requirements_install_fail():
+    "Check that parsing fails with an exception"
+    with pytest.raises(ValueError) as error:
+        get_setup_cfg_install({"options": {"something": []}})
+    assert "Missing 'install_requires'" in str(error)
+
+
+def test_parse_requirements_extras_fail():
+    "Check that parsing fails with an exception"
+    with pytest.raises(ValueError) as error:
+        get_setup_cfg_extras({"options": {"something": []}})
+    assert "Missing 'options.extras_require'" in str(error)
+
+
+def test_parse_requirements_build_fail():
+    "Check that parsing fails with an exception"
+    with pytest.raises(ValueError) as error:
+        get_pyproject_toml_build({"meh": ["something"]})
+    assert "Missing 'build-system'" in str(error)
+    with pytest.raises(ValueError) as error:
+        get_pyproject_toml_build({"build-system": {"something": []}})
+    assert "Missing 'requires'" in str(error)

--- a/env/requirements-test.txt
+++ b/env/requirements-test.txt
@@ -1,2 +1,4 @@
 # Testing
 pytest
+pytest-cov
+coverage

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,8 @@ dependencies:
   - build
   # Testing
   - pytest
+  - pytest-cov
+  - coverage
   # Linting and style
   - black
   - isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,15 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
+include_package_data = True
 python_requires = >=3.6
 install_requires =
     click>=8.0.0,<9.0.0
     rich>=9.6.0,<11.0.0
     tomli>=1.0.0,<3.0.0
+
+[options.package_data]
+dependente.tests = data/*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Split out functionality into small functions that can be tested apart from the CLI. Add tests for the functions that parse input files only.