### PR TITLE
Add option to pin dependencies to the oldest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install the oldest supported version of dependencies
         if: matrix.dependencies == 'oldest'
         run: |
-          dependente > requirements-oldest.txt
+          dependente --source install --oldest > requirements-oldest.txt
           python -m pip install --requirement requirements-oldest.txt
 
       - name: List installed packages

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -59,78 +59,81 @@ def main(source, oldest, verbose):
     * setup.cfg (install_requires and options.extras_require)
 
     """
-    console = make_console(verbose)
-    console_error = make_console(verbose=True)
-    style = "bold blue"
-    console.print(
-        f":rocket: Extracting dependencies: {source}",
-        style=style,
-    )
-    sources = parse_sources(source)
+    reporter = Reporter(verbose, style="bold blue", style_error="bold red")
     readers = {"setup.cfg": read_setup_cfg, "pyproject.toml": read_pyproject_toml}
-    dependencies = []
-    for config_file in sources:
-        if not sources[config_file]:
-            continue
-        try:
-            console.print(f":mag_right: Parsing {config_file}: ", end="", style=style)
+    reporter.echo(f":rocket: Extracting dependencies: {source}")
+    try:
+        sources = parse_sources(source)
+        dependencies = []
+        for config_file in sources:
+            if not sources[config_file]:
+                continue
+            reporter.echo(f":mag_right: Parsing {config_file}")
             config = readers[config_file]()
             dependencies_found = parse_requirements(config, sources[config_file])
-            console.print(
-                f"{count(dependencies_found)} dependencies found", style=style
-            )
+            reporter.echo(f"   - {count(dependencies_found)} dependencies found")
             dependencies.extend(dependencies_found)
-        except Exception:
-            style = "bold red"
-            console_error.rule(
-                ":fire: The following errors were encountered: :fire:", style=style
+        if oldest:
+            reporter.echo(
+                ":mantelpiece_clock:  Pinning dependencies to their oldest versions"
             )
-            console_error.print_exception(suppress=[click, rich])
-            console_error.rule(":fire: End of error messages :fire:", style=style)
-            console_error.print()
-            console_error.print(
-                f":pensive: Sorry! Could not extract dependencies from '{config_file}'",
-                style=style,
-            )
-            sys.exit(1)
-    if oldest:
-        console.print(
-            ":mantelpiece_clock:  Pinning dependencies to their oldest versions",
-            style=style,
+            dependencies = pin_to_oldest(dependencies)
+        reporter.echo(
+            f":printer:  Printing {count(dependencies)} dependencies to the "
+            "standard output stream",
         )
-        dependencies = pin_to_oldest(dependencies)
-    console.print(
-        f":printer:  Printing {count(dependencies)} dependencies to the "
-        "standard output stream",
-        style=style,
-    )
-    for line in dependencies:
-        click.echo(line)
-    console.print(":partying_face: [bold green]Done![/] :partying_face:", style=style)
-    sys.exit(0)
+        for line in dependencies:
+            click.echo(line)
+        reporter.echo(":partying_face: [bold green]Done![/] :partying_face:")
+        sys.exit(0)
+    except Exception:
+        reporter.console.print_exception(suppress=[click, rich])
+        reporter.error(
+            "\n:fire::fire::fire: Error encountered while processing. "
+            "See the message and traceback above. :fire::fire::fire:"
+        )
+        sys.exit(1)
 
 
 def count(dependencies):
     """
     Count the number of dependencies in a list.
-
     Ignores any comments (entries starting with #).
     """
     return len([i for i in dependencies if not i.strip().startswith("#")])
 
 
-def make_console(verbose):
+class Reporter:
     """
-    Start up the :class:`rich.console.Console` instance we'll use.
+    Small wrapper around :class:`rich.console.Console` to control verbosity.
 
-    Parameters
-    ----------
-    verbose : bool
-        Whether or not to print status messages to stderr.
-
-    Returns
-    -------
-    console
-        A Console instance.
+    Use *echo* to print according to verbosity settings and *error* to always
+    print regardless of settings.
     """
-    return rich.console.Console(stderr=True, quiet=not verbose, highlight=False)
+
+    def __init__(self, verbose, style, style_error):
+        self.verbose = verbose
+        self.style = style
+        self.style_error = style_error
+        self.console = rich.console.Console(stderr=True, highlight=False)
+
+    def _print(self, message, style, **kwargs):
+        """
+        Print the message with the given style using rich.
+        """
+        arguments = {"style": style}
+        arguments.update(kwargs)
+        self.console.print(message, **arguments)
+
+    def echo(self, message, **kwargs):
+        """
+        Print the message if verbosity is enabled.
+        """
+        if self.verbose:
+            self._print(message, style=self.style, **kwargs)
+
+    def error(self, message, **kwargs):
+        """
+        Print the message regardless of verbosity settings.
+        """
+        self._print(message, style=self.style_error, **kwargs)

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -87,7 +87,7 @@ def main(source, oldest, verbose):
         reporter.echo(":partying_face: [bold green]Done![/] :partying_face:")
         sys.exit(0)
     except Exception:
-        reporter.console.print_exception(suppress=[click, rich])
+        reporter.console.print_exception()
         reporter.error(
             "\n:fire::fire::fire: Error encountered while processing. "
             "See the message and traceback above. :fire::fire::fire:"

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -11,6 +11,7 @@ import sys
 import click
 import rich.console
 
+from .converters import pin_to_oldest
 from .parsers import (
     parse_requirements,
     parse_sources,
@@ -29,6 +30,14 @@ from .parsers import (
     "Can be any combination of 'install,extras,build'.",
 )
 @click.option(
+    "--oldest",
+    "-o",
+    default=False,
+    show_default=True,
+    is_flag=True,
+    help="If enabled, will pin dependencies to the oldest accepted version.",
+)
+@click.option(
     "--verbose/--quiet",
     "-v/-q",
     default=True,
@@ -36,7 +45,7 @@ from .parsers import (
     help="Print information during execution / Don't print",
 )
 @click.version_option()
-def main(source, verbose):
+def main(source, oldest, verbose):
     """
     Dependente: Extract Python package dependencies from configuration files.
 
@@ -84,6 +93,12 @@ def main(source, verbose):
                 style=style,
             )
             sys.exit(1)
+    if oldest:
+        console.print(
+            ":mantelpiece_clock:  Pinning dependencies to their oldest versions",
+            style=style,
+        )
+        dependencies = pin_to_oldest(dependencies)
     console.print(
         f":printer:  Printing {count(dependencies)} dependencies to the "
         "standard output stream",

--- a/dependente/converters.py
+++ b/dependente/converters.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Functions for manipulating/converting dependency lists.
+"""
+
+
+def pin_to_oldest(requirements):
+    """
+    Convert the list of requirements to pin the oldest supported version.
+
+    Parameters
+    ----------
+    requirements : list
+        List of requirements (strings). May contain comments (starting with #)
+        that are copied verbatim to the output.
+
+    Returns
+    -------
+    oldest : list
+        List of requirements pinned to the oldest supported version.
+    """
+    oldest = [
+        package.split(",")[0].replace(">=", "==").strip() for package in requirements
+    ]
+    return oldest

--- a/dependente/converters.py
+++ b/dependente/converters.py
@@ -21,7 +21,10 @@ def pin_to_oldest(requirements):
     oldest : list
         List of requirements pinned to the oldest supported version.
     """
-    oldest = [
-        package.split(",")[0].replace(">=", "==").strip() for package in requirements
-    ]
+    oldest = []
+    for line in requirements:
+        if line.strip().startswith("#"):
+            oldest.append(line)
+        else:
+            oldest.append(line.split(",")[0].replace(">=", "==").strip())
     return oldest

--- a/dependente/parsers.py
+++ b/dependente/parsers.py
@@ -32,7 +32,7 @@ def parse_sources(source):
     for entry in sorted(source.strip().split(",")):
         if entry not in valid_sources:
             raise ValueError(
-                f"Invalid source '{entry}'. Must be one of {valid_sources}."
+                f"Invalid source '{entry}'. Must be one of {list(valid_sources.keys())}."
             )
         sources[valid_sources[entry]["file"]].append(valid_sources[entry]["option"])
     return sources
@@ -43,7 +43,10 @@ def read_setup_cfg(fname="setup.cfg"):
     Read the setup.cfg file into a dictionary.
     """
     config = configparser.ConfigParser()
-    config.read(fname)
+    # Use read_file to get a FileNotFoundError if setup.cfg is missing. Using
+    # read returns an empty config instead of raising an exception.
+    with open(fname, "rt") as config_source:
+        config.read_file(config_source)
     config_dict = {
         section: dict((key, value.strip()) for key, value in config.items(section))
         for section in config.sections()

--- a/dependente/tests/test_converters.py
+++ b/dependente/tests/test_converters.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Test functions for converting/transforming dependencies.
+"""
+import pytest
+
+from ..converters import pin_to_oldest
+
+
+@pytest.mark.parametrize(
+    "requirements,expected",
+    [
+        (["bla>=12"], ["bla==12"]),
+        (["bla<12"], ["bla<12"]),
+        (["bla>=11,<12"], ["bla==11"]),
+        (["# meh", "bla>=11,<12", "# foo"], ["# meh", "bla==11", "# foo"]),
+    ],
+    ids=["lower", "upper", "both", "comment"],
+)
+def test_pin_to_oldest(requirements, expected):
+    "Check that pinning works"
+    assert expected == pin_to_oldest(requirements)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ python_requires = >=3.6
 install_requires =
     click>=8.0.0,<9.0.0
     rich>=9.6.0,<11.0.0
-    tomli>=1.0.0,<3.0.0
+    tomli>=1.1.0,<3.0.0
 
 [options.package_data]
 dependente.tests = data/*


### PR DESCRIPTION
Add the `-o/--oldest` flag that pins dependencies to their oldest supported version (basically replace `>=` with `==`).