### PR TITLE
Remove rich as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ The current implementation is a proof-of-concept and has some limitations:
 Of course, all of these could be addressed if there is enough interest.
 Issues and PRs are welcome!
 
+## Dependencies
+
+We use the following dependencies (see `setup.cfg` for specific version
+constraints):
+
+* [click](https://click.palletsprojects.com) for building the command-line
+  interface.
+* [tomli](https://github.com/hukkin/tomli) to parse the TOML configuration
+  files.
+
 ## Contacting Us
 
 Find out more about how to reach us at

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -74,9 +74,7 @@ def main(source, oldest, verbose):
             reporter.echo(f"  - {count(dependencies_found)} dependencies found")
             dependencies.extend(dependencies_found)
         if oldest:
-            reporter.echo(
-                "Pinning dependencies to their oldest versions"
-            )
+            reporter.echo("Pinning dependencies to their oldest versions")
             dependencies = pin_to_oldest(dependencies)
         reporter.echo(
             f"Printing {count(dependencies)} dependencies to standard output",
@@ -85,13 +83,9 @@ def main(source, oldest, verbose):
             click.echo(line)
         reporter.echo("Done!")
     except Exception:
-        reporter.error(
-            "\nError encountered while processing:\n"
-        )
+        reporter.error("\nError encountered while processing:\n")
         reporter.error(traceback.format_exc())
-        reporter.error(
-            "Oh no! Something went wrong. See the messages above."
-        )
+        reporter.error("Oh no! Something went wrong. See the messages above.")
         sys.exit(1)
 
 

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -7,9 +7,9 @@ Defines the command line interface.
 Uses click to define a CLI around the ``main`` function.
 """
 import sys
+import traceback
 
 import click
-import rich.console
 
 from .converters import pin_to_oldest
 from .parsers import (
@@ -59,38 +59,38 @@ def main(source, oldest, verbose):
     * setup.cfg (install_requires and options.extras_require)
 
     """
-    reporter = Reporter(verbose, style="bold blue", style_error="bold red")
+    reporter = Reporter(verbose)
     readers = {"setup.cfg": read_setup_cfg, "pyproject.toml": read_pyproject_toml}
-    reporter.echo(f":rocket: Extracting dependencies: {source}")
+    reporter.echo(f"Extracting dependencies: {source}")
     try:
         sources = parse_sources(source)
         dependencies = []
         for config_file in sources:
             if not sources[config_file]:
                 continue
-            reporter.echo(f":mag_right: Parsing {config_file}")
+            reporter.echo(f"Parsing {config_file}")
             config = readers[config_file]()
             dependencies_found = parse_requirements(config, sources[config_file])
-            reporter.echo(f"   - {count(dependencies_found)} dependencies found")
+            reporter.echo(f"  - {count(dependencies_found)} dependencies found")
             dependencies.extend(dependencies_found)
         if oldest:
             reporter.echo(
-                ":mantelpiece_clock:  Pinning dependencies to their oldest versions"
+                "Pinning dependencies to their oldest versions"
             )
             dependencies = pin_to_oldest(dependencies)
         reporter.echo(
-            f":printer:  Printing {count(dependencies)} dependencies to the "
-            "standard output stream",
+            f"Printing {count(dependencies)} dependencies to standard output",
         )
         for line in dependencies:
             click.echo(line)
-        reporter.echo(":partying_face: [bold green]Done![/] :partying_face:")
-        sys.exit(0)
+        reporter.echo("Done!")
     except Exception:
-        reporter.console.print_exception()
         reporter.error(
-            "\n:fire::fire::fire: Error encountered while processing. "
-            "See the message and traceback above. :fire::fire::fire:"
+            "\nError encountered while processing:\n"
+        )
+        reporter.error(traceback.format_exc())
+        reporter.error(
+            "Oh no! Something went wrong. See the messages above."
         )
         sys.exit(1)
 
@@ -105,35 +105,24 @@ def count(dependencies):
 
 class Reporter:
     """
-    Small wrapper around :class:`rich.console.Console` to control verbosity.
+    Small wrapper around click.echo to control verbosity.
 
     Use *echo* to print according to verbosity settings and *error* to always
     print regardless of settings.
     """
 
-    def __init__(self, verbose, style, style_error):
+    def __init__(self, verbose):
         self.verbose = verbose
-        self.style = style
-        self.style_error = style_error
-        self.console = rich.console.Console(stderr=True, highlight=False)
 
-    def _print(self, message, style, **kwargs):
-        """
-        Print the message with the given style using rich.
-        """
-        arguments = {"style": style}
-        arguments.update(kwargs)
-        self.console.print(message, **arguments)
-
-    def echo(self, message, **kwargs):
+    def echo(self, message):
         """
         Print the message if verbosity is enabled.
         """
         if self.verbose:
-            self._print(message, style=self.style, **kwargs)
+            click.echo(message, err=True)
 
-    def error(self, message, **kwargs):
+    def error(self, message):
         """
         Print the message regardless of verbosity settings.
         """
-        self._print(message, style=self.style_error, **kwargs)
+        click.echo(message, err=True)

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - make
   # Run-time
   - click>=8.0.0,<9.0.0
-  - rich>=9.6.0,<11.0.0
   - tomli>=1.0.0,<3.0.0
   # Building (excluding setuptools)
   - build

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     click>=8.0.0,<9.0.0
-    rich>=9.6.0,<11.0.0
     tomli>=1.1.0,<3.0.0
 
 [options.package_data]


### PR DESCRIPTION
It was only used to make the CLI output pretty but it's not worth the
extra dependency just for that. Keep this simple.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
