### PR TITLE
Drop support for Python 3.6 and add 3.11 + 3.12

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install requirements
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,6 @@ on:
   release:
     types:
       - published
-  schedule:
-    # Run every Monday at 12:00 UTC
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '00 12 * * 1'
 
 # Use bash by default in all jobs
 defaults:
@@ -43,12 +39,14 @@ jobs:
           - ubuntu
           - macos
           - windows
-        python:
-          - "3.6"
-          - "3.10"
         dependencies:
           - latest
           - oldest
+        include:
+          - dependencies: oldest
+            python: "3.7"
+          - dependencies: latest
+            python: "3.12"
     env:
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.10
+  - python==3.12
   - pip
   - make
   # Run-time
@@ -26,6 +26,5 @@ dependencies:
   - flake8-mutable
   - flake8-rst-docstrings
   - flake8-simplify
+  - flake8-unused-arguments
   - pep8-naming
-  - pip:
-    - flake8-unused-arguments

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,12 @@ classifiers =
     Operating System :: OS Independent
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 url = https://github.com/fatiando/dependente
 project_urls =
     Release Notes = https://github.com/fatiando/dependente/releases
@@ -36,7 +37,7 @@ project_urls =
 zip_safe = True
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     click>=8.0.0,<9.0.0
     tomli>=1.1.0,<3.0.0


### PR DESCRIPTION
Also remove the cron job from the test Action and simplify the test matrix to only check oldest Python with oldest dependencies and newest with newest.


