### PR TITLE
Use Burocrata to check/add license notices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:
 format:
 	isort $(CHECK_STYLE)
 	black $(CHECK_STYLE)
+	burocrata --extension=py $(CHECK_STYLE)
 
 check: check-format check-style
 
@@ -40,6 +41,7 @@ check-style:
 check-format:
 	isort --check $(CHECK_STYLE)
 	black --check $(CHECK_STYLE)
+	burocrata --check --extension=py $(CHECK_STYLE)
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;

--- a/dependente/__init__.py
+++ b/dependente/__init__.py
@@ -1,11 +1,13 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Dependente: Extract Python package dependencies from configuration files.
 
 The _version module is generated automatically by setuptools_scm at build time.
 """
+
 from . import _version
 
 __version__ = f"v{_version.version}"

--- a/dependente/cli.py
+++ b/dependente/cli.py
@@ -1,11 +1,13 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Defines the command line interface.
 
 Uses click to define a CLI around the ``main`` function.
 """
+
 import sys
 import traceback
 from pathlib import Path

--- a/dependente/converters.py
+++ b/dependente/converters.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Functions for manipulating/converting dependency lists.
 """

--- a/dependente/parsers.py
+++ b/dependente/parsers.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Functions for extracting the dependency information from files.
 """
+
 import configparser
 from pathlib import Path
 

--- a/dependente/tests/__init__.py
+++ b/dependente/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 The Dependente Developers.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).

--- a/dependente/tests/conftest.py
+++ b/dependente/tests/conftest.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Fixtures for pytest
 """
+
 from pathlib import Path
 
 import pytest

--- a/dependente/tests/test_cli_utils.py
+++ b/dependente/tests/test_cli_utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 The Dependente Developers.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Test utility functions from cli.py
 """

--- a/dependente/tests/test_converters.py
+++ b/dependente/tests/test_converters.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Test functions for converting/transforming dependencies.
 """
+
 import pytest
 
 from ..converters import pin_to_oldest

--- a/dependente/tests/test_parsers.py
+++ b/dependente/tests/test_parsers.py
@@ -1,11 +1,13 @@
-# Copyright (c) 2021 Leonardo Uieda.
+# Copyright (c) 2021 The Dependente Developers.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).
 """
 Test the functions that extract content from configuration files.
 
 The fixtures (arguments to the test functions) are defined in conftest.py
 """
+
 import pytest
 
 from ..parsers import ParserPyprojectToml, ParserSetupCfg, get_parser, validate_sources

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -10,3 +10,4 @@ flake8-rst-docstrings
 flake8-simplify
 flake8-unused-arguments
 pep8-naming
+burocrata

--- a/environment.yml
+++ b/environment.yml
@@ -28,3 +28,5 @@ dependencies:
   - flake8-simplify
   - flake8-unused-arguments
   - pep8-naming
+  - pip:
+    - burocrata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,10 @@ write_to =  "dependente/_version.py"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[tool.burocrata]
+notice = '''
+# Copyright (c) 2021 The Dependente Developers.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org).'''


### PR DESCRIPTION
Add the check and format rules to the Makefile and use the tool to update the copyright notice to Dependente Developers instead of me personally.

