### PR TITLE
Minor correction to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ The current implementation is a proof-of-concept and has some limitations:
 * Input files must be in the current working directory.
 * Reads all extra dependencies simultaneously (can't separate between different
   `option.extras_requires` fields).
-* Only supports reading from `setup.cfg` and `pyproject.toml` (build
-  dependencies only).
+* Only supports reading from `setup.cfg` and `pyproject.toml`.
 
 Of course, all of these could be addressed if there is enough interest.
 Issues and PRs are welcome!


### PR DESCRIPTION
Remove parenthesis regarding support for `pyproject.toml` files: since v0.3.0 dependente can handle dependencies in `pyproject.toml` files (besides the ones for building).